### PR TITLE
Temporarily fix for TLS erlang problem.

### DIFF
--- a/src/dp_push_apns.erl
+++ b/src/dp_push_apns.erl
@@ -15,7 +15,7 @@ send(#apns_msg{} = Msg, DeviceToken, #apns{host = Host, port = Port},
     Json = wrap_to_json(Msg),
     case byte_size(Json) of
 	Len when Len > 255 -> {error, too_big, Len};
-	_ -> case ssl:connect(Host, Port, [{certfile, Certfile}, {password, Password}]) of
+	_ -> case ssl:connect(Host, Port, [{certfile, Certfile}, {password, Password}, {versions,['tlsv1.1']}]) of
 		 {ok, Socket} -> ok = ssl:send(Socket, pack_simple(Json, DeviceToken)),
 				 ssl:close(Socket),
 				 ok;


### PR DESCRIPTION
Hi! 

This fix problem shown here:
https://blog.process-one.net/apple-increasing-security-of-push-service-ahead-of-wwdc/

Fix taken from this thread:

http://erlang.org/pipermail/erlang-questions/2015-June/084864.html
